### PR TITLE
sdcv for cygwin port

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,7 @@
 See sdcv man page for usage description.
 See INSTALL file for installation description.
 
+
+depend libs:
+  libpcre zlib glibmm-2.4 glib-2.0 iconv mmap ...
+

--- a/config.h.in
+++ b/config.h.in
@@ -41,6 +41,9 @@
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
+/* Define to 1 if you have the <sys/param.h> header file. */
+#undef HAVE_SYS_PARAM_H
+
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 
@@ -67,6 +70,9 @@
 
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
 
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_SRCDIR(src/sdcv.cpp)
 dnl Don't include maintainer make-rules by default
 AM_MAINTAINER_MODE
 
-AM_INIT_AUTOMAKE([dist-bzip2])
+AM_INIT_AUTOMAKE(sdcv, 0.4.4)
 
 AM_CONFIG_HEADER(config.h)
 AC_PROG_CC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ sdcv_SOURCES = \
 	utils.cpp utils.hpp
 
 sdcv_DEPENDENCIES = lib/libstardict.a
-sdcv_LDADD = @SDCV_LIBS@ @LIBINTL@ @LIBREADLINE@ lib/libstardict.a
+sdcv_LDADD =  lib/libstardict.a @SDCV_LIBS@ @LIBINTL@ @LIBREADLINE@
 localedir = $(datadir)/locale
 
 INCLUDES = @SDCV_CFLAGS@  -I$(top_builddir) -Ilib

--- a/src/sdcv.cpp
+++ b/src/sdcv.cpp
@@ -27,12 +27,12 @@
 #include <cstdlib>
 #include <cstdio>
 #include <clocale>
-#include <glib.h>
-#include <glib/gi18n.h>
-#include <glib/gstdio.h>
 #include <string>
 #include <vector>
 #include <memory>
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
 
 #include "libwrapper.hpp"
 #include "readline.hpp"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -25,6 +25,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <cstdlib>
+#include <stdio.h>
 
 #include "utils.hpp"
 


### PR DESCRIPTION
last commit for depending libs;
others for fixing compiling errors.

like:
macro defining of header files 
adjust sequence of loading libs & functions
